### PR TITLE
Make boot stack size configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Made boot stack size configurable.
+
 ## 0.1.0
 
 Initial release.

--- a/image.ld
+++ b/image.ld
@@ -67,9 +67,11 @@ SECTIONS
 
 	.stack (NOLOAD) : ALIGN(4096) {
 		boot_stack_begin = .;
-		. += 40 * 4096;
+		KEEP(*(.stack.boot_stack))
 		. = ALIGN(4096);
 		boot_stack_end = .;
+
+		KEEP(*(.stack.*))
 	} >image
 
 	. = ALIGN(4K);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,12 @@ impl<const NUM_PAGES: usize> Stack<NUM_PAGES> {
     }
 }
 
+impl<const NUM_PAGES: usize> Default for Stack<NUM_PAGES> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[repr(C, align(4096))]
 struct StackPage([u8; 4096]);
 


### PR DESCRIPTION
40 pages (160 KiB) remains the default.