### PR TITLE
Make set_exception_vector and enable_mmu public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Made `set_exception_vector` public.
+
 ## 0.4.0
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Made `set_exception_vector` public.
+- Made `enable_mmu` public.
 
 ## 0.4.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,12 +47,23 @@ pub use pagetable::{
     InitialPagetable,
 };
 
+/// No-op when the `initial-pagetable` feature isn't enabled.
 #[cfg(not(feature = "initial-pagetable"))]
 #[unsafe(naked)]
 #[unsafe(link_section = ".init")]
 #[unsafe(export_name = "enable_mmu")]
-extern "C" fn enable_mmu() {
+pub extern "C" fn enable_mmu() {
     naked_asm!("ret")
+}
+
+#[cfg(feature = "initial-pagetable")]
+unsafe extern "C" {
+    /// Enables the MMU and caches with the initial pagetable.
+    ///
+    /// This is called automatically from entry point code both for primary and secondary CPUs so
+    /// you usually won't need to call this yourself, but is available in case you need to implement
+    /// your own assembly entry point.
+    pub safe fn enable_mmu();
 }
 
 /// Sets the appropriate vbar to point to our `vector_table`, if the `exceptions` feature is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,9 @@ extern "C" fn enable_mmu() {
 
 /// Sets the appropriate vbar to point to our `vector_table`, if the `exceptions` feature is
 /// enabled.
-extern "C" fn set_exception_vector() {
+///
+/// If `exceptions` is not enabled then this is a no-op.
+pub extern "C" fn set_exception_vector() {
     // SAFETY: We provide a valid vector table.
     #[cfg(all(feature = "el1", feature = "exceptions"))]
     unsafe {


### PR DESCRIPTION
This allows users to implement their own secondary entry points if they want to.