### PR TITLE
Mark bss as NOLOAD

### DIFF
--- a/image.ld
+++ b/image.ld
@@ -57,7 +57,7 @@ SECTIONS
 	bin_end = .;
 
 	/* The entry point code assumes that .bss is 16-byte aligned. */
-	.bss : ALIGN(16)  {
+	.bss (NOLOAD) : ALIGN(16)  {
 		bss_begin = .;
 		*(.bss.*)
 		*(COMMON)


### PR DESCRIPTION
It’s not mandatory, because bss is zeroed in `entry!` stage. 